### PR TITLE
Add placeholder pages to xosmox-frontend

### DIFF
--- a/xosmox-frontend/src/pages/Register.tsx
+++ b/xosmox-frontend/src/pages/Register.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const Register: React.FC = () => {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Register</h1>
+      <p className="text-gray-600">Registration form coming soon.</p>
+    </div>
+  )
+}
+
+export default Register

--- a/xosmox-frontend/src/pages/Trading.tsx
+++ b/xosmox-frontend/src/pages/Trading.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const Trading: React.FC = () => {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Trading</h1>
+      <p className="text-gray-600">Trading interface coming soon.</p>
+    </div>
+  )
+}
+
+export default Trading

--- a/xosmox-frontend/src/pages/Wallet.tsx
+++ b/xosmox-frontend/src/pages/Wallet.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const Wallet: React.FC = () => {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Wallet</h1>
+      <p className="text-gray-600">Wallet management coming soon.</p>
+    </div>
+  )
+}
+
+export default Wallet


### PR DESCRIPTION
## Summary
- add Register, Trading and Wallet pages under xosmox-frontend
- ensure routing imports these new pages

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its types)*

------
https://chatgpt.com/codex/tasks/task_e_685822d73d9483329a5f728446186352