### PR TITLE
Fix Snyk workflow to produce SARIF report

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,8 @@ jobs:
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
-        args: --severity-threshold=high
+        command: test
+        args: --sarif-file-output=snyk.sarif --severity-threshold=high
     
     - name: Upload Snyk results
       uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
## Summary
- fix Snyk GitHub Action step to output SARIF file

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68620e8588388332b8495db4a1d8b477