### PR TITLE
Fix Snyk SARIF output path

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,7 @@ jobs:
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:
-        args: --severity-threshold=high
+        args: --severity-threshold=high --sarif-file-output=snyk.sarif
     
     - name: Upload Snyk results
       uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
## Summary
- ensure security workflow generates SARIF file for Snyk results

## Testing
- `npm test -- --passWithNoTests` in `xosmox-backend`
- `npm test -- --watchAll=false` *(fails: Missing script)* in `frontend`
- `npm run build` *(fails: cannot find React TS declarations)* in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6862582074c08332be329444ea7d8fa9